### PR TITLE
Fix correctness bugs (subsample, vicinity p-values, community labels, register) — v0.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           uv run bandit --verbose --ini .bandit.ini -ll --recursive spatiomic
       - name: Test with pytest
         run: |
-          uv run coverage run -m pytest --maxfail=10 -m "not gpu" -m "not no_github_ci"
+          uv run coverage run -m pytest --maxfail=10 -m "not gpu and not no_github_ci"
           uv run coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["spatiomic"]
 
 [project]
 name = "spatiomic"
-version = "0.9.2"
+version = "0.9.3"
 description = "A python toolbox for spatial omics analysis."
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/spatiomic/cluster/__init__.py
+++ b/spatiomic/cluster/__init__.py
@@ -8,7 +8,6 @@ from ._leiden import Leiden as leiden
 
 __all__ = [
     "agglomerative",
-    "biclustering",
     "kmeans",
     "leiden",
     "som",

--- a/spatiomic/data/_subsample.py
+++ b/spatiomic/data/_subsample.py
@@ -1,4 +1,5 @@
 from typing import Any, Literal
+from warnings import warn
 
 import numpy as np
 from numpy.typing import NDArray
@@ -46,10 +47,22 @@ class Subsample:
             assert 0 < fraction <= 1, "Fraction must be between 0 and 1."
             count = int(np.floor(fraction * pixel_count))
 
+        if count > pixel_count:
+            warn(
+                f"Requested subsample count ({count}) exceeds the number of available pixels ({pixel_count}). "
+                "Returning all available pixels.",
+                UserWarning,
+                stacklevel=2,
+            )
+            count = int(pixel_count)
+
+        # Sample WITHOUT replacement so that no pixel is duplicated in the subsample. Duplicated pixels would
+        # otherwise bias any estimator fitted on the subsample (e.g. clip/normalize percentiles, SOM training).
         subsample_pixels = data.reshape((-1, dimension_count))[
             np.random.choice(
                 pixel_count,
                 size=count,
+                replace=False,
             ),
             :,
         ]

--- a/spatiomic/dimension/_som.py
+++ b/spatiomic/dimension/_som.py
@@ -346,7 +346,9 @@ class Som(LoadableDimensionReducer):
         else:
             neighbor_idx = np.array(result)
 
-        data_labelled = np.array([clusters[neighbor] for neighbor in neighbor_idx.ravel()])
+        # Vectorized node-label lookup (equivalent to indexing clusters by each nearest-node id, but avoids
+        # a per-pixel Python loop that is prohibitively slow at full image resolution).
+        data_labelled = clusters[np.asarray(neighbor_idx).ravel()]
         data_labelled = data_labelled.reshape(data_shape[:-1]) if not flatten else data_labelled
 
         # save the labelled data if a path was provided

--- a/spatiomic/process/_register.py
+++ b/spatiomic/process/_register.py
@@ -314,8 +314,10 @@ class Register:
         else:
             raise ValueError("Shift can only be applied to image in XY or XYC format.")
 
-        # check that cupy exists and that pixels is a cupy array
-        if use_gpu and "cp" in globals() and isinstance(pixels, cp.NDArray):  # type: ignore
+        # Move a cupy result back to the host so a numpy array is always returned. `cp` is imported locally
+        # inside the `use_gpu` branch above, so the previous `"cp" in globals()` guard was always False (leaking
+        # a cupy array); duck-typing on `.get` is robust regardless of how the array was produced.
+        if hasattr(pixels, "get"):
             pixels = pixels.get()  # type: ignore
 
         return pixels.astype(np.float32 if precision == "float32" else np.float64)

--- a/spatiomic/segment/_assign_communities.py
+++ b/spatiomic/segment/_assign_communities.py
@@ -50,9 +50,11 @@ def assign_communities(
     # Initialize output with same shape as masks
     community_image = np.zeros_like(masks)
 
-    # Assign community labels (adding 1 to avoid confusion with background, if needed)
-    pseudocount = 1 if communities_array.min() == 0 else 0
+    # Assign community labels with a fixed offset of 1. This reserves value 0 for the background and, crucially,
+    # keeps the mapping community -> pixel value identical across images. A data-dependent offset (e.g. only
+    # adding 1 when a community 0 is present) would map the same community integer to different pixel values in
+    # different images, making labelled images non-comparable across a cohort.
     for i, region_id in enumerate(unique_regions):
-        community_image[masks == region_id] = communities_array[i] + pseudocount
+        community_image[masks == region_id] = communities_array[i] + 1
 
     return community_image

--- a/spatiomic/segment/_count_clusters.py
+++ b/spatiomic/segment/_count_clusters.py
@@ -64,7 +64,14 @@ def count_clusters(
             region_mask = masks_xp == region
             if xp.any(region_mask):
                 region_clusters = clustered_img_xp[region_mask]
-                counts = xp.bincount(region_clusters, minlength=cluster_count)[:cluster_count]
+                max_cluster_id = int(region_clusters.max())
+                if max_cluster_id >= cluster_count:
+                    raise ValueError(
+                        f"clustered_img contains cluster id {max_cluster_id}, which is out of range for "
+                        f"cluster_count={cluster_count}. Increase cluster_count to at least "
+                        f"{max_cluster_id + 1} to avoid silently dropping counts."
+                    )
+                counts = xp.bincount(region_clusters, minlength=cluster_count)
                 cluster_counts[i, :] = counts
 
     # Convert back to numpy for pandas compatibility

--- a/spatiomic/spatial/_spatial_weights.py
+++ b/spatiomic/spatial/_spatial_weights.py
@@ -74,8 +74,8 @@ def spatial_weights(
         data_shape = (3, 3)
         neighborhood_offset = neighborhood_offset(
             neighborhood_type="queen",
-            steps=5,
-            exclude_inner_steps=2,
+            order=2,
+            exclude_inner_order=1,
         )
         spatial_weights_matrix = spatial_weights(
             data_shape,

--- a/spatiomic/spatial/_vicinity_composition.py
+++ b/spatiomic/spatial/_vicinity_composition.py
@@ -161,9 +161,11 @@ def vicinity_composition(
         if xp.__name__ == "cupy":
             xp.random.seed(seed + permutation_seed)
 
-        # Generate permutation and calculate vicinity composition
+        # Generate permutation and calculate vicinity composition. The cluster labels must be permuted across
+        # ALL pixels (complete spatial randomness): permuting the 2D image directly only shuffles rows and
+        # preserves within-row spatial structure, which yields anti-conservative, invalid p-values.
         return calculate_vicinity_composition(
-            xp.random.permutation(data),
+            xp.random.permutation(data.ravel()).reshape(data.shape),
             neighborhood_offset,
             ignore_identities,
             ignore_repeated,

--- a/test/data/test_subsample.py
+++ b/test/data/test_subsample.py
@@ -1,5 +1,7 @@
 """Test the Subsample class."""
 
+import numpy as np
+import pytest
 from anndata import AnnData
 from numpy.typing import NDArray
 
@@ -24,3 +26,25 @@ def test_subsample(
     _ = subsample.fit_transform(adata, fraction=0.1, output_unstructured_name="X_subsample")
 
     assert adata.uns["X_subsample"].shape[0] == int(0.1 * image_pixels.shape[0])
+
+
+def test_subsample_without_replacement() -> None:
+    """Subsampling must not duplicate pixels (sampling without replacement)."""
+    # Each pixel has a unique value so any duplication or omission is detectable.
+    pixels = np.arange(200, dtype=np.float32).reshape((-1, 1))
+
+    result = subsample.fit_transform(pixels, method="count", count=200, seed=0)
+
+    assert result.shape[0] == 200
+    assert np.array_equal(np.sort(result.ravel()), np.arange(200))
+
+
+def test_subsample_count_exceeds_pixels_is_clamped() -> None:
+    """Requesting more pixels than available clamps to all pixels (with a warning), without replacement."""
+    pixels = np.arange(50, dtype=np.float32).reshape((-1, 1))
+
+    with pytest.warns(UserWarning):
+        result = subsample.fit_transform(pixels, method="count", count=1000, seed=0)
+
+    assert result.shape[0] == 50
+    assert np.array_equal(np.sort(result.ravel()), np.arange(50))

--- a/test/segment/test_assign_communities.py
+++ b/test/segment/test_assign_communities.py
@@ -1,0 +1,41 @@
+"""Test the assign_communities function."""
+
+import numpy as np
+import pytest
+
+from spatiomic.segment import assign_communities
+
+
+@pytest.mark.cpu
+def test_assign_communities_offset() -> None:
+    """Community k maps to pixel value k + 1; background stays 0."""
+    masks = np.array([[0, 1, 1], [0, 2, 2]], dtype=np.int32)
+    communities = [0, 1]  # region 1 -> community 0, region 2 -> community 1
+
+    result = assign_communities(masks, communities)
+
+    np.testing.assert_array_equal(result, np.array([[0, 1, 1], [0, 2, 2]]))
+
+
+@pytest.mark.cpu
+def test_assign_communities_offset_is_fixed_across_images() -> None:
+    """The community -> pixel-value mapping must not depend on whether community 0 is present."""
+    masks = np.array([[0, 1, 1], [0, 2, 2]], dtype=np.int32)
+
+    result_a = assign_communities(masks, [0, 1])  # communities include 0
+    result_b = assign_communities(masks, [1, 2])  # 1-indexed, no 0
+
+    # community k -> pixel value k + 1 in BOTH images (previously the offset was data-dependent)
+    assert result_a[0, 1] == 1  # community 0 -> 1
+    assert result_a[1, 1] == 2  # community 1 -> 2
+    assert result_b[0, 1] == 2  # community 1 -> 2 (same mapping as image A)
+    assert result_b[1, 1] == 3  # community 2 -> 3
+
+
+@pytest.mark.cpu
+def test_assign_communities_length_mismatch_raises() -> None:
+    """A community count that does not match the number of mask regions must raise."""
+    masks = np.array([[0, 1], [2, 2]], dtype=np.int32)
+
+    with pytest.raises(ValueError, match="must match"):
+        assign_communities(masks, [0])  # only one community for two regions

--- a/test/segment/test_count_clusters.py
+++ b/test/segment/test_count_clusters.py
@@ -164,6 +164,16 @@ def test_count_clusters_different_dtypes() -> None:
 
 
 @pytest.mark.cpu
+def test_count_clusters_out_of_range_raises() -> None:
+    """A cluster id >= cluster_count must raise instead of being silently dropped."""
+    clustered = np.array([[0, 1], [2, 5]], dtype=np.int32)  # id 5 is out of range for cluster_count=3
+    mask = np.array([[1, 1], [1, 1]], dtype=np.int32)
+
+    with pytest.raises(ValueError, match="out of range"):
+        so.segment.count_clusters(clustered_img=clustered, masks=mask, cluster_count=3, use_gpu=False)
+
+
+@pytest.mark.cpu
 def test_count_clusters_zero_division_in_normalization() -> None:
     """Test handling of empty regions during normalization."""
     # Create a case where a mask region has no pixels

--- a/test/spatial/test_vicinity_composition.py
+++ b/test/spatial/test_vicinity_composition.py
@@ -32,6 +32,32 @@ def test_vicinity_composition(
         "The DataFrame columns are not the same as the unique values in the data."
     )
 
-    assert all(result.values.diagonal() == 0), "The DataFrame diagonal values are not all 0."
+    assert all(result.to_numpy().diagonal() == 0), "The DataFrame diagonal values are not all 0."
 
-    assert np.array_equal(result.values, result.values.T), "The DataFrame values are not symmetric."
+    assert np.array_equal(result.to_numpy(), result.to_numpy().T), "The DataFrame values are not symmetric."
+
+
+def test_vicinity_composition_permutation(
+    clustered_data: np.ndarray,
+) -> None:
+    """The permutation path returns valid p-values with the correct shape."""
+    n = len(np.unique(clustered_data))
+
+    result, p_values = vicinity_composition(
+        clustered_data.astype(np.uint16),
+        permutations=20,
+        seed=0,
+        n_jobs=1,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert isinstance(p_values, pd.DataFrame)
+    assert p_values.shape == (n, n)
+
+    # p-values must lie in (0, 1]
+    p_values_array = p_values.to_numpy()
+    finite_p_values = p_values_array[~np.isnan(p_values_array)]
+    assert np.all((finite_p_values > 0) & (finite_p_values <= 1))
+
+    # ignore_identities defaults to True, so the diagonal is NaN
+    assert np.all(np.isnan(np.diag(p_values_array)))

--- a/test/test_public_api.py
+++ b/test/test_public_api.py
@@ -1,0 +1,26 @@
+"""Ensure each submodule's ``__all__`` matches its actual public exports."""
+
+import importlib
+
+import pytest
+
+SUBMODULES = [
+    "cluster",
+    "data",
+    "dimension",
+    "neighbor",
+    "plot",
+    "process",
+    "segment",
+    "spatial",
+    "tool",
+]
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("submodule", SUBMODULES)
+def test_all_names_are_importable(submodule: str) -> None:
+    """Every name declared in a submodule's ``__all__`` must be a real attribute of that submodule."""
+    module = importlib.import_module(f"spatiomic.{submodule}")
+    missing = [name for name in getattr(module, "__all__", []) if not hasattr(module, name)]
+    assert not missing, f"spatiomic.{submodule}.__all__ lists names that do not exist: {missing}"

--- a/uv.lock
+++ b/uv.lock
@@ -5545,7 +5545,7 @@ wheels = [
 
 [[package]]
 name = "spatiomic"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "adjusttext" },


### PR DESCRIPTION
## Summary

`v0.9.3` — a correctness-focused patch with **no public API changes**. Fixes nine issues found during an architecture/correctness review, including three that change numeric outputs.

> ⚠️ **Reproducibility:** three fixes change numeric results (vicinity p-values, subsample dedup, community label offset). To exactly reproduce a prior analysis (e.g. the published PathoPlex/Nature pipeline), pin `spatiomic<0.9.3`.

## Results-affecting fixes

- **`spatial.vicinity_composition` permutation p-values were invalid.** The null shuffled the 2-D cluster image directly, which only permutes rows and preserves within-row spatial structure → anti-conservative p-values. Labels are now permuted across all pixels (`permutation(data.ravel()).reshape(...)`, i.e. complete spatial randomness). *(Added the first test of this path.)*
- **`data.subsample` sampled with replacement**, duplicating pixels used to fit `clip`/`normalize`/`zscore` and train the SOM. Now samples **without replacement**; over-requests clamp to all pixels with a warning.
- **`segment.assign_communities` used a data-dependent `+1` offset**, so the same community integer could map to different pixel values across images. Now a fixed `+1` (a no-op for the usual 0-indexed Leiden case).

## Correctness / safety

- **`segment.count_clusters`** now raises `ValueError` on cluster ids `>= cluster_count` instead of silently truncating via `bincount`.
- **`process.register.apply_shift`** now returns numpy — the previous host-transfer guard (`"cp" in globals()`, plus a non-existent `cp.NDArray`) was dead code and leaked a cupy array on the GPU path. ⚠️ This is a GPU-only path with no GPU CI; worth one smoke test on CUDA hardware before tagging.
- **`dimension.Som.label`** vectorized (identical results, removes a per-pixel Python loop).

## Packaging / docs / CI

- Removed the phantom `biclustering` from `cluster.__all__`; added `test/test_public_api.py` asserting every submodule's `__all__` is importable.
- Fixed the CI marker filter: `-m "not gpu and not no_github_ci"` (two separate `-m` flags silently kept only the last, so GPU-marked tests were **not** deselected).
- Fixed the `spatial_weights` docstring example (`order`/`exclude_inner_order` instead of non-existent `steps`/`exclude_inner_steps`).
- Version bump `0.9.2 → 0.9.3`.

## Testing

- Full CI-equivalent suite: **72 passed, 1 deselected, 0 failed**.
- 6 new tests: subsample dedup + clamp, vicinity permutation path, count_clusters out-of-range, assign_communities fixed offset (×3), public-API `__all__` guard.
- `ruff` lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
